### PR TITLE
chore: Move common workflows to .github folder

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -2,6 +2,7 @@ name: Build, lint and test
 
 on:
   workflow_dispatch:
+  workflow_call:
   pull_request:
     branches:
       - main
@@ -23,8 +24,8 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test
-        if: {{ github.repository != 'cloudscape-design/components' }}
+        if: ${{ github.repository != 'cloudscape-design/components' }}
       - run: npm run test:unit
-        if: {{ github.repository == 'cloudscape-design/components' }}
+        if: ${{ github.repository == 'cloudscape-design/components' }}
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,11 +1,7 @@
 name: Build, lint and test
 
 on:
-  workflow_dispatch:
   workflow_call:
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Moving the common workflows to the `.github` folder because otherwise the Runner won't find it. See https://github.com/cloudscape-design/components/actions/runs/2705147627.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
