### PR TITLE
Move remaining workflows and actions to this repository

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -41,7 +41,7 @@ runs:
     - run: cd ${{ inputs.package }}
       shell: bash
 
-    - uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@chore/shared-actions
+    - uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@main
       with:
         path: ${{ github.workspace }}/${{ inputs.package }}
         type: local

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -1,0 +1,114 @@
+name: "Build dependency package locally"
+description: "Checks out a dependency package locally and updates all references to it"
+inputs:
+  package:
+    description: "Name of the package"
+    required: true
+  download_dependencies:
+    description: "Whether to download dependencies"
+    default: "false"
+  skip_build:
+    description: "Whether to skip the build"
+    default: "false"
+  skip_tests:
+    description: "Whether to skip the tests"
+    default: "false"
+  target_artifact:
+    description: "Name of the artifact that will be uploaded"
+    default: "dependencies"
+  artifact_path:
+    description: "Path or pattern for the artifact files that should be uploaded"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+    - name: Clone
+      uses: actions/checkout@v2
+      with:
+        repository: cloudscape-design/${{ inputs.package }}
+        path: ${{ inputs.package }}
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+
+    - name: Download artifacts
+      if: ${{ inputs.download_dependencies == 'true' }}
+      uses: actions/download-artifact@v2
+      with:
+        name: dependencies
+
+    - run: cd ${{ inputs.package }}
+      shell: bash
+
+    - uses: ./.github/actions/patch-local-dependencies
+      with:
+        path: ${{ github.workspace }}/${{ inputs.package }}
+        type: local
+
+    - name: npm install
+      shell: bash
+      run: npm i
+      working-directory: ${{ inputs.package }}
+    - name: Build
+      if: ${{ inputs.skip_build != 'true' }}
+      shell: bash
+      run: npm run build
+      working-directory: ${{ inputs.package }}
+    - name: Test
+      if: ${{ inputs.skip_tests != 'true' }}
+      shell: bash
+      run: npm test
+      working-directory: ${{ inputs.package }}
+    - name: Pack artifacts
+      if: ${{ inputs.package != 'components' && inputs.package != 'test-utils' && inputs.package != 'theming-core' }}
+      shell: bash
+      working-directory: ${{ inputs.package }}
+      run: |
+        npm pack
+        cp *-${{ inputs.package }}-*.tgz $GITHUB_WORKSPACE/${{ inputs.package }}.tgz
+
+    - name: Pack test-utils artifacts
+      if: ${{ inputs.package == 'test-utils' }}
+      shell: bash
+      working-directory: ${{ inputs.package }}
+      run: |
+        cd packages/core
+        npm pack
+        cp *-test-utils-core-*.tgz $GITHUB_WORKSPACE
+        cd ../converter
+        npm pack
+        echo $GITHUB_WORKSPACE
+        cp *-test-utils-converter-*.tgz $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE
+        mv *-test-utils-converter-*.tgz test-utils-converter.tgz
+        mv *-test-utils-core-*.tgz test-utils-core.tgz
+
+    - name: Pack theming-core artifacts
+      if: ${{ inputs.package == 'theming-core' }}
+      shell: bash
+      working-directory: ${{ inputs.package }}
+      run: |
+        cd lib/browser
+        npm pack
+        cp *-theming-runtime-*.tgz $GITHUB_WORKSPACE
+        cd ../node
+        npm pack
+        echo $GITHUB_WORKSPACE
+        cp *-theming-build-*.tgz $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE
+        mv *-theming-build-*.tgz theming-build.tgz
+        mv *-theming-runtime-*.tgz theming-runtime.tgz
+
+    - name: Package component files
+      if: ${{ inputs.package == 'components' }}
+      shell: bash
+      working-directory: ${{ inputs.package }}
+      run: tar -czf ../components.tgz --strip-components=1 .
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.target_artifact }}
+        path: ${{ inputs.artifact_path || format('{0}*.tgz', inputs.package) }}

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -22,7 +22,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
     - name: Clone
       uses: actions/checkout@v2
       with:
@@ -42,7 +41,7 @@ runs:
     - run: cd ${{ inputs.package }}
       shell: bash
 
-    - uses: ./.github/actions/patch-local-dependencies
+    - uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@chore/shared-actions
       with:
         path: ${{ github.workspace }}/${{ inputs.package }}
         type: local

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -1,0 +1,23 @@
+name: "Patch package.json with local dependencies"
+description: "Modifies the current package.json to point to local repositories instead"
+inputs:
+  path:
+    description: "Root directory of the package that should be updated"
+    required: true
+  type:
+    description: 'How the dependencies should change. Possible values: "local" (to consume local tarballs), and "next" (to consume from pre-release CodeArtifact)'
+    default: "local"
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+    - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/local.mjs
+      if: ${{ inputs.type == 'local' }}
+      shell: bash
+    - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/next.mjs
+      if: ${{ inputs.type == 'next' }}
+      shell: bash

--- a/.github/actions/patch-local-dependencies/local.mjs
+++ b/.github/actions/patch-local-dependencies/local.mjs
@@ -1,0 +1,5 @@
+import { updatePackageJsons } from './utils.mjs';
+
+updatePackageJsons(
+  (packageName) => `file:${process.env.GITHUB_WORKSPACE}/${packageName.replace('@cloudscape-design/', '')}.tgz`
+);

--- a/.github/actions/patch-local-dependencies/next.mjs
+++ b/.github/actions/patch-local-dependencies/next.mjs
@@ -1,0 +1,3 @@
+import { updatePackageJsons } from './utils.mjs';
+
+updatePackageJsons(() => 'next');

--- a/.github/actions/patch-local-dependencies/utils.mjs
+++ b/.github/actions/patch-local-dependencies/utils.mjs
@@ -1,0 +1,106 @@
+import path from 'path';
+import fs from 'fs';
+
+const inputs = {
+  path: process.env.INPUT_PATH,
+};
+
+function findPackageFiles(directory) {
+  const files = [];
+
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  ['package.json', 'package-lock.json'].forEach(fileName => {
+    const packageJson = path.join(directory, fileName);
+    if (fs.existsSync(packageJson)) {
+      files.push(packageJson);
+    }
+  });
+
+  return files;
+}
+
+function findAllPackageJsons() {
+  const files = [];
+
+  if (!inputs.path || !fs.existsSync(inputs.path)) {
+    console.error(`Invalid input path: ${inputs.path}`);
+    process.exit(1);
+  }
+
+  const mainPackageJsons = findPackageFiles(inputs.path);
+  if (mainPackageJsons.length) {
+    files.push(...mainPackageJsons);
+  }
+
+  const subPackagesPath = path.join(inputs.path, 'packages');
+  if (fs.existsSync(subPackagesPath)) {
+    fs.readdirSync(subPackagesPath).forEach(fileName => {
+      const filePath = path.join(subPackagesPath, fileName);
+      if (fs.statSync(filePath).isDirectory()) {
+        const packageJsons = findPackageFiles(filePath);
+        if (packageJsons) {
+          files.push(...packageJsons);
+        }
+      }
+    });
+  }
+
+  return files;
+}
+
+function updateDependencyVersions(dependencies, newVersion, sourcePackageName) {
+  if (!dependencies) {
+    return;
+  }
+
+  const updatedDependencies = {};
+
+  Object.keys(dependencies)
+    .filter(packageName => packageName.startsWith('@cloudscape-design/'))
+    .forEach(packageName => {
+      const isPackageLock = typeof dependencies[packageName] !== 'string';
+      const previousVersion = isPackageLock ? dependencies[packageName].version : dependencies[packageName];
+
+      // Skip local file dependencies
+      if (previousVersion.startsWith('file:')) {
+        return;
+      }
+
+      // Don't touch this local lerna dependency in test-utils-converter
+      if (sourcePackageName === '@cloudscape-design/test-utils-converter' && packageName === '@cloudscape-design/test-utils-core') {
+        return;
+      }
+
+      const nextVersion = typeof newVersion === 'function' ? newVersion(packageName) : newVersion;
+
+      if (isPackageLock) {
+        updatedDependencies[packageName] = { ...dependencies[packageName], version: nextVersion };
+
+        // Remove some additional keys for package-lock.json files
+        delete updatedDependencies[packageName].resolved;
+        delete updatedDependencies[packageName].integrity;
+      } else {
+        updatedDependencies[packageName] = nextVersion;
+      }
+    });
+
+  return { ...dependencies, ...updatedDependencies };
+}
+
+export function updatePackageJsons(newVersion) {
+  const packageJsons = findAllPackageJsons();
+  packageJsons.forEach(filePath => {
+    const packageJson = JSON.parse(fs.readFileSync(filePath));
+    const packageName = packageJson.name;
+
+    ['dependencies', 'devDependencies'].forEach(dependencyKey => {
+      const newDeps = updateDependencyVersions(packageJson[dependencyKey], newVersion, packageName);
+      packageJson[dependencyKey] = newDeps;
+    });
+
+    fs.writeFileSync(filePath, JSON.stringify(packageJson, null, 2));
+  });
+}

--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -1,0 +1,17 @@
+name: "Publish package to internal CodeArtifact"
+description: "Publishes the current package to an internal CodeArtifact on a pre-release tag"
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+
+    - name: Define new version suffix
+      id: vars
+      run: echo "::set-output name=version_suffix::-next-build.$(git rev-parse --short HEAD)"
+      shell: bash
+
+    - run: INPUT_PATH=${{ github.workspace }} INPUT_SUFFIX=${{ steps.vars.outputs.version_suffix }} node ${{ github.action_path }}/index.mjs
+      shell: bash

--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -1,0 +1,67 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+
+const inputs = {
+  path: process.env.INPUT_PATH,
+  suffix: process.env.INPUT_SUFFIX,
+};
+
+// The main packags should publish to next, and dev forks to next-dev
+const branchName = process.env.GITHUB_REF_TYPE === 'branch' ? process.env.GITHUB_REF_NAME : '';
+const publishTag = branchName.startsWith('dev-v3-') ? branchName : 'next';
+
+const subPackages = {
+  'components': [
+    'lib/components',
+    'lib/style-dictionary',
+    'lib/components-themeable',
+    'lib/dev-pages',
+    'lib/components-definitions',
+  ],
+  'theming-core': ['lib/node', 'lib/browser'],
+  'test-utils': ['packages/core', 'packages/converter'],
+};
+
+function releasePackage(packagePath) {
+  const packageJsonPath = path.join(packagePath, 'package.json');
+
+  // Update version in the package.json file
+  const packageJson = JSON.parse(readFileSync(packageJsonPath));
+  packageJson.version += inputs.suffix;
+  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+  // Publish to CodeArtifact
+  console.info(`Publishing package ${packageJson.name} version ${packageJson.version} to dist-tag ${publishTag}`);
+
+  try {
+    execSync(`npm publish --tag ${publishTag}`, { stdio: 'inherit', cwd: packagePath });
+  } catch (e) {
+    console.error('Error while publishing:', e.stderr.toString());
+  }
+}
+
+function main() {
+  const basePath = inputs.path;
+
+  if (!basePath && !existsSync(basePath)) {
+    console.error(`Invalid path: ${basePath}`);
+    process.exit(1);
+  }
+
+  if (!inputs.suffix) {
+    console.error('No version suffix provided.');
+    process.exit(1);
+  }
+
+  const repositoryName = path.basename(basePath);
+  if (subPackages[repositoryName]) {
+    subPackages[repositoryName].forEach(subpath => {
+      releasePackage(path.join(basePath, subpath));
+    });
+  } else {
+    releasePackage(basePath);
+  }
+}
+
+main();

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,154 @@
+# This workflow executes a full dry-run test, which means that all we build and test all @cloudscape-design packages in GitHub.
+# This ensures that the changes in the current package do not cause any regressions for its consumers.
+name: dry-run
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  buildJestPreset:
+    name: Build jest-preset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: jest-preset
+          skip_build: "true"
+  buildGlobalStyles:
+    name: Build global-styles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: global-styles
+  buildCollectionHooks:
+    name: Build collection-hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: collection-hooks
+  buildBrowserTestTools:
+    name: Build browser-test-tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: browser-test-tools
+  buildDocumenter:
+    name: Build documenter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: documenter
+  buildTestUtils:
+    name: Build test-utils
+    runs-on: ubuntu-latest
+    needs: buildDocumenter
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: test-utils
+          download_dependencies: "true"
+  buildThemingCore:
+    name: Build theming-core
+    runs-on: ubuntu-latest
+    needs:
+      - buildBrowserTestTools
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: theming-core
+          artifact_path: theming-*.tgz
+          download_dependencies: true
+  buildComponents:
+    name: Build components
+    runs-on: ubuntu-latest
+    needs:
+      - buildJestPreset
+      - buildGlobalStyles
+      - buildCollectionHooks
+      - buildBrowserTestTools
+      - buildDocumenter
+      - buildTestUtils
+      - buildThemingCore
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+        with:
+          package: components
+          target_artifact: components-package
+          skip_tests: true
+          download_dependencies: true
+
+  unitTest:
+    name: Components unit tests
+    runs-on: ubuntu-latest
+    needs:
+      - buildComponents
+    steps:
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Download component artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: components-package
+      - name: Unpack components artifacts
+        run: tar -xzf components.tgz
+      - name: Unit tests
+        run: npm run test:unit
+
+  integTest:
+    name: Components integration tests
+    runs-on: ubuntu-latest
+    needs:
+      - buildComponents
+    steps:
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Download component artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: components-package
+      - name: Unpack components artifacts
+        run: tar -xzf components.tgz
+      - name: Integration tests
+        run: npm run test:integ
+
+  a11yTest:
+    name: Components accessibility tests
+    runs-on: ubuntu-latest
+    needs:
+      - buildComponents
+    steps:
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Download component artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: components-package
+      - name: Unpack components artifacts
+        run: tar -xzf components.tgz
+      - name: Accessibility tests
+        run: npm run test:a11y

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -17,8 +17,7 @@ jobs:
     name: Build jest-preset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: jest-preset
           skip_build: "true"
@@ -26,32 +25,28 @@ jobs:
     name: Build global-styles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: global-styles
   buildCollectionHooks:
     name: Build collection-hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: collection-hooks
   buildBrowserTestTools:
     name: Build browser-test-tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: browser-test-tools
   buildDocumenter:
     name: Build documenter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: documenter
   buildTestUtils:
@@ -59,8 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: buildDocumenter
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: test-utils
           download_dependencies: "true"
@@ -70,8 +64,7 @@ jobs:
     needs:
       - buildBrowserTestTools
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: theming-core
           artifact_path: theming-*.tgz
@@ -88,8 +81,7 @@ jobs:
       - buildTestUtils
       - buildThemingCore
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/build-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
         with:
           package: components
           target_artifact: components-package

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build jest-preset
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: jest-preset
           skip_build: "true"
@@ -25,28 +25,28 @@ jobs:
     name: Build global-styles
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: global-styles
   buildCollectionHooks:
     name: Build collection-hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: collection-hooks
   buildBrowserTestTools:
     name: Build browser-test-tools
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: browser-test-tools
   buildDocumenter:
     name: Build documenter
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: documenter
   buildTestUtils:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: buildDocumenter
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: test-utils
           download_dependencies: "true"
@@ -64,7 +64,7 @@ jobs:
     needs:
       - buildBrowserTestTools
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: theming-core
           artifact_path: theming-*.tgz
@@ -81,7 +81,7 @@ jobs:
       - buildTestUtils
       - buildThemingCore
     steps:
-      - uses: cloudscape-design/.github/.github/actions/build-package@chore/shared-actions
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
         with:
           package: components
           target_artifact: components-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# This workflow releases the current package to a dedicated private CodeArtifact repository.
+# One repository may publish more than one package. For more details refer to the release-package Action.
+name: release
+
+on:
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  release:
+    concurrency: release-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+      - name: Login and configure codeartifact
+        env:
+          CODE_ARTIFACT_REPO: ${{ startsWith(github.ref_name, 'dev-v3-') && format('AwsUI-Artifacts-{0}', github.ref_name) || 'github-artifacts' }}
+        run: |
+          echo Logging into repository $CODE_ARTIFACT_REPO
+          aws codeartifact login --tool npm --repository $CODE_ARTIFACT_REPO --domain awsui --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region us-west-2 --namespace @cloudscape-design
+
+      - name: Make sure to use pre-release versions of our dependencies
+        uses: ./.github/actions/patch-local-dependencies
+        with:
+          path: ${{ github.workspace }}
+          type: next
+
+      - run: npm install
+
+      - name: Restore locally modified files
+        run: git restore .
+
+      - run: npm run test
+
+      - name: Release package to private CodeArtifact
+        uses: ./.github/actions/release-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           aws codeartifact login --tool npm --repository $CODE_ARTIFACT_REPO --domain awsui --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region us-west-2 --namespace @cloudscape-design
 
       - name: Make sure to use pre-release versions of our dependencies
-        uses: ./.github/actions/patch-local-dependencies
+        uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@chore/shared-actions
         with:
           path: ${{ github.workspace }}
           type: next
@@ -45,4 +45,4 @@ jobs:
       - run: npm run test
 
       - name: Release package to private CodeArtifact
-        uses: ./.github/actions/release-package
+        uses: cloudscape-design/.github/.github/actions/release-package@chore/shared-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           aws codeartifact login --tool npm --repository $CODE_ARTIFACT_REPO --domain awsui --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region us-west-2 --namespace @cloudscape-design
 
       - name: Make sure to use pre-release versions of our dependencies
-        uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@chore/shared-actions
+        uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@main
         with:
           path: ${{ github.workspace }}
           type: next
@@ -45,4 +45,4 @@ jobs:
       - run: npm run test
 
       - name: Release package to private CodeArtifact
-        uses: cloudscape-design/.github/.github/actions/release-package@chore/shared-actions
+        uses: cloudscape-design/.github/.github/actions/release-package@main


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Move all remaining shared workflows to this repository.

No need to actually review the content of the workflows because they were just copied over from the components repository. For the workflows, I simply changed the `on` trigger to only include `workflow_call`

Checked with the `documenter` package that the workflows can be called correctly: https://github.com/cloudscape-design/documenter/pull/7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
