### PR TITLE
fix: Make sure to build packages in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Restore locally modified files
         run: git restore .
 
+      - run: npm run build
       - run: npm run test
 
       - name: Release package to private CodeArtifact


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Make sure to run `npm run build` in the release workflow. Some packages call it as part of their `pretest` scripts, but some don't.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
