### PR TITLE
Allow to configure publish paths in the release workflow

### DIFF
--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -1,5 +1,11 @@
 name: "Publish package to internal CodeArtifact"
 description: "Publishes the current package to an internal CodeArtifact on a pre-release tag"
+inputs:
+  publish-packages:
+    # Arrays are not supported: https://github.com/community/community/discussions/11692
+    description: "Comma-separated list of sub-folders to publish"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -13,5 +19,9 @@ runs:
       run: echo "::set-output name=version_suffix::-next-build.$(git rev-parse --short HEAD)"
       shell: bash
 
-    - run: INPUT_PATH=${{ github.workspace }} INPUT_SUFFIX=${{ steps.vars.outputs.version_suffix }} node ${{ github.action_path }}/index.mjs
+    - run: node ${{ github.action_path }}/index.mjs
       shell: bash
+      env:
+        INPUT_PATH: ${{ github.workspace }}
+        INPUT_SUFFIX: ${{ steps.vars.outputs.version_suffix }}
+        PUBLISH_PACKAGES: ${{ inputs.publish-packages }}

--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -5,14 +5,15 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 const inputs = {
   path: process.env.INPUT_PATH,
   suffix: process.env.INPUT_SUFFIX,
+  publishPackages: process.env.PUBLISH_PACKAGES?.split(',').map((pkg) => pkg.trim()),
 };
 
-// The main packags should publish to next, and dev forks to next-dev
+// The main branch should publish to next, and dev forks to next-dev
 const branchName = process.env.GITHUB_REF_TYPE === 'branch' ? process.env.GITHUB_REF_NAME : '';
 const publishTag = branchName.startsWith('dev-v3-') ? branchName : 'next';
 
 const subPackages = {
-  'components': [
+  components: [
     'lib/components',
     'lib/style-dictionary',
     'lib/components-themeable',
@@ -55,12 +56,10 @@ function main() {
   }
 
   const repositoryName = path.basename(basePath);
-  if (subPackages[repositoryName]) {
-    subPackages[repositoryName].forEach(subpath => {
-      releasePackage(path.join(basePath, subpath));
-    });
-  } else {
-    releasePackage(basePath);
+  const packagesToPublish = inputs.publishPackages ?? subPackages[repositoryName] ?? ['.'];
+
+  for (const pkg of packagesToPublish) {
+    releasePackage(path.join(basePath, pkg));
   }
 }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ name: release
 
 on:
   workflow_call:
+    inputs:
+      publish-packages:
+        description: "Comma-separated list of sub-folders to publish"
+        type: string
+        required: false
 
 permissions:
   id-token: write
@@ -47,3 +52,5 @@ jobs:
 
       - name: Release package to private CodeArtifact
         uses: cloudscape-design/.github/.github/actions/release-package@main
+        with:
+          publish-packages: ${{ inputs.publish-packages }}


### PR DESCRIPTION
With this change, we can configure this action on consumer's end

```yml
jobs:
  release:
    uses: cloudscape-design/.github/.github/workflows/release.yml@main
    with:
      publish-packages: lib/components,lib/design-tokens,lib/dev-pages
```

This allows to have granular control on the release process without editing this package for every change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
