### PR TITLE
chore: Cache global package data for NPM

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'npm'
       - run: npm i
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'npm'
       - name: Download component artifacts
         uses: actions/download-artifact@v2
         with:
@@ -117,6 +118,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'npm'
       - name: Download component artifacts
         uses: actions/download-artifact@v2
         with:
@@ -136,6 +138,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'npm'
       - name: Download component artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'npm'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Caching of global package data is disabled by default. This does not cache the `node_modules` folder.

For reference: 
https://github.com/actions/setup-node#caching-global-packages-data

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
