### PR TITLE
fix: Log publishing error to console

### DIFF
--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -31,7 +31,7 @@ function releasePackage(packagePath) {
   try {
     execSync(`npm publish --tag ${publishTag}`, { stdio: 'inherit', cwd: packagePath });
   } catch (e) {
-    console.error('Error while publishing:', e.stderr.toString());
+    console.error(`Publishing failed with ${e.status}: ${e.message}. ${e.stderr ? 'Full error: ' + e.stderr.toString() : ''}`);
   }
 }
 


### PR DESCRIPTION
`stderr` can be `null` as seen here:
https://github.com/cloudscape-design/components/actions/runs/3084288653/jobs/4986262826