### PR TITLE
Revert "chore: Cache global package data for NPM"

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          cache: 'npm'
       - run: npm i
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -98,7 +98,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          cache: 'npm'
       - name: Download component artifacts
         uses: actions/download-artifact@v2
         with:
@@ -118,7 +117,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          cache: 'npm'
       - name: Download component artifacts
         uses: actions/download-artifact@v2
         with:
@@ -138,7 +136,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          cache: 'npm'
       - name: Download component artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          cache: 'npm'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
This PR reverts cloudscape-design/.github#11

## Reason:
This seems to be causing pipeline failures on every new commit in [components](https://github.com/cloudscape-design/components)