### PR TITLE
feat: create manifest file on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,11 @@ jobs:
         run: git restore .
 
       - run: npm run build
-      - run: npm run test
 
+      - name: Save commit in manifest file
+        run: echo '{"commit":"${{ github.sha }}"}' > manifest.json
+
+      - run: npm run test
       - name: Release package to private CodeArtifact
         uses: cloudscape-design/.github/.github/actions/release-package@main
         with:


### PR DESCRIPTION
*Description of changes:*

Create a manifest file and add a `commit` field with the latest commit in it. 
This file will be used when the npm package is published to release notes to github 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
