### PR TITLE
chore: Add validate PR title workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,27 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          types: |
+            fix
+            feat
+            test
+            refactor
+            chore
+          requireScope: false
+          scopes: |
+            scope-not-allowed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Description of changes:*

Add a workflow to validate PR title to match conventional commits, requirements: 
1- type must be one of these: feat, fix, chore, refactor, or test
2- no scopes allowed, enabled this in a hacky way by making the only scope allowed is: "scope-not-allowed"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
