### PR TITLE
chore: add manifest file to packages

### DIFF
--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -25,3 +25,4 @@ runs:
         INPUT_PATH: ${{ github.workspace }}
         INPUT_SUFFIX: ${{ steps.vars.outputs.version_suffix }}
         PUBLISH_PACKAGES: ${{ inputs.publish-packages }}
+        COMMIT_SHA: ${{ github.sha }}

--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -8,6 +8,7 @@ const inputs = {
   publishPackages: process.env.PUBLISH_PACKAGES
     ? process.env.PUBLISH_PACKAGES.split(',').map((pkg) => pkg.trim())
     : null,
+    commitSha: process.env.COMMIT_SHA,
 };
 
 console.log('Inputs:');
@@ -33,6 +34,13 @@ function releasePackage(packagePath) {
   } catch (e) {
     console.error(`Publishing failed with ${e.status}: ${e.message}. ${e.stderr ? 'Full error: ' + e.stderr.toString() : ''}`);
   }
+}  
+
+function addManifest(data, packagePath) {
+  writeFileSync(
+    path.join(packagePath, "manifest.json"),
+    JSON.stringify(data, null, 2)
+  );
 }
 
 function main() {
@@ -51,7 +59,9 @@ function main() {
   const packagesToPublish = inputs.publishPackages ?? ['.'];
 
   for (const pkg of packagesToPublish) {
-    releasePackage(path.join(basePath, pkg));
+    const packagePath = path.join(basePath, pkg);
+    addManifest({ commit: inputs.commitSha }, packagePath);
+    releasePackage(packagePath);
   }
 }
 

--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -38,7 +38,7 @@ function releasePackage(packagePath) {
 
 function addManifest(data, packagePath) {
   writeFileSync(
-    path.join(packagePath, "manifest.json"),
+    path.join(packagePath, 'manifest.json'),
     JSON.stringify(data, null, 2)
   );
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,6 @@ jobs:
 
       - run: npm run build
 
-      - name: Save commit in manifest file
-        run: echo '{"commit":"${{ github.sha }}"}' > manifest.json
-
       - run: npm run test
       - name: Release package to private CodeArtifact
         uses: cloudscape-design/.github/.github/actions/release-package@main


### PR DESCRIPTION
*Description of changes:*

- create manifest file in monorepo packages, the previous approach https://github.com/cloudscape-design/.github/pull/16 works only for other packages but not components since its a monorepo


tested in my dev-branch


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
