### PR TITLE
fix: Replace semantic pr action with custom implementation

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,16 +12,12 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        with:
-          types: |
-            fix
-            feat
-            test
-            refactor
-            chore
-          requireScope: false
-          scopes: |
-            scope-not-allowed
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ (^(chore|feat|fix|refactor|test){1}?: ([[:alnum:]])+([[:space:][:print:]]*)) ]]; then
+           echo "Valid PR title"
+          else 
+           echo 'PR title does not follow the convention "type: subject"'
+           echo 'type must be one of the following: feat|fix|chore|refactor|test'
+           exit 1
+          fi
+        shell: bash


### PR DESCRIPTION
*Description of changes:*
To avoid passing out github token secret to an opensource action, this commit replaces the action with a custom regex validation that checks our convention.


tested in my forked repo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
