### PR TITLE
fix: trigger lint-pr workflow on workflow call

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,11 +1,7 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  workflow_call:
 
 jobs:
   main:


### PR DESCRIPTION
*Description of changes:*

This workflow will be called from other workflow so it should be triggered on `workflow_call` not `pull_request_target`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
