### PR TITLE
Skip PR title linting

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: 'Lint PR'
 
 on:
   workflow_call:
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ (^(chore|feat|fix|refactor|test|revert){1}?: ([[:alnum:]])+([[:space:][:print:]]*)) ]]; then
-           echo "Valid PR title"
-          else 
-           echo 'PR title does not follow the convention "type: subject"'
-           echo 'type must be one of the following: feat|fix|chore|refactor|test|revert'
-           exit 1
-          fi
+          echo "Skipped"
+          exit 1
         shell: bash


### PR DESCRIPTION
*Issue #, if available:*
AWSUI-19888

*Description of changes:*
This change skips the execution of the PR linting step.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
