### PR TITLE
fix: Use environment variables and remove permissions in Lint PR workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,14 +1,23 @@
-name: 'Lint PR'
+name: Lint PR
 
 on:
   workflow_call:
+
+permissions: {}
 
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
     steps:
       - run: |
-          echo "Skipped"
-          exit 1
+          if [[ "$TITLE" =~ (^(chore|feat|fix|refactor|test|revert){1}?: ([[:alnum:]])+([[:space:][:print:]]*)) ]]; then
+           echo "Valid PR title"
+          else 
+           echo 'PR title does not follow the convention "type: subject"'
+           echo 'type must be one of the following: feat|fix|chore|refactor|test|revert'
+           exit 1
+          fi
         shell: bash


### PR DESCRIPTION
*Issue #, if available:* AWSUI-19888

*Description of changes:* 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
