### PR TITLE
chore: rewrite PR title linting workflow in py3

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,8 +15,8 @@ jobs:
       - run: |
           import os, re
           valid_types = ['chore', 'feat', 'fix', 'refactor', 'test', 'revert']
-          title = os.environ['TITLE']
           try:
+              title = os.environ['TITLE']
               segments = re.split(r':\s*', title, maxsplit=1)
               if (len(segments) != 2):
                   raise Exception('PR title does not follow "type: subject" convention')

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -20,7 +20,7 @@ jobs:
               if (len(segments) != 2):
                   raise Exception('PR title does not follow "type: subject" convention')
               type, subject = segments
-              if type.lower() not in valid_types:
+              if type not in valid_types:
                   raise Exception('Invalid commit type')
               if not all(c.isprintable() for c in subject):
                   raise Exception('Invalid commit subject')

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -13,11 +13,21 @@ jobs:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
       - run: |
-          if [[ "$TITLE" =~ (^(chore|feat|fix|refactor|test|revert){1}?: ([[:alnum:]])+([[:space:][:print:]]*)) ]]; then
-           echo "Valid PR title"
-          else 
-           echo 'PR title does not follow the convention "type: subject"'
-           echo 'type must be one of the following: feat|fix|chore|refactor|test|revert'
-           exit 1
-          fi
-        shell: bash
+          import os, re
+          valid_types = ['chore', 'feat', 'fix', 'refactor', 'test', 'revert']
+          try:
+              segments = re.split(r':\s*', os.getenv('TITLE', ''))
+              if (len(segments) != 2):
+                  raise Exception('Invalid number of commit types used')
+              type, subject = segments
+              if type.lower() not in valid_types:
+                  raise Exception('Invalid commit type')
+              if not all(c.isprintable() for c in subject):
+                  raise Exception('Invalid commit subject')
+              print('PR title is valid')
+              exit(0)
+          except Exception as e:
+              print('Error: {}'.format(e.args[0]))
+              print('PR title does not follow the convention "type: subject"\nValid types are: {}'.format(', '.join(valid_types)))
+              exit(1)
+        shell: python

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,6 +15,7 @@ jobs:
       - run: |
           import os, re
           valid_types = ['chore', 'feat', 'fix', 'refactor', 'test', 'revert']
+          title = os.environ['TITLE']
           try:
               segments = re.split(r':\s*', title, maxsplit=1)
               if (len(segments) != 2):

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -16,9 +16,9 @@ jobs:
           import os, re
           valid_types = ['chore', 'feat', 'fix', 'refactor', 'test', 'revert']
           try:
-              segments = re.split(r':\s*', os.getenv('TITLE', ''))
+              segments = re.split(r':\s*', title, maxsplit=1)
               if (len(segments) != 2):
-                  raise Exception('Invalid number of commit types used')
+                  raise Exception('PR title does not follow "type: subject" convention')
               type, subject = segments
               if type.lower() not in valid_types:
                   raise Exception('Invalid commit type')


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
This is a complete rewrite of the script in python, using as little regex as possible.

> Why Python?

Github Actions natively support inline python script, and I'd argue its more readable than bash-ism like `[[` and `=~`.

> Why do you hate regex?

I like regex, but a long regex is very difficult to debug and opens us up to horrible possibilities like ReDoS. That said, feel free to use more regex features from python's `re` module to improve the script even more.

> So this is just a rewrite? Why bother?

Because it's Friday, and there is an improvement (albeit small); you can now see why the linting failed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
