### PR TITLE
Allow skipping tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         description: "Comma-separated list of sub-folders to publish"
         type: string
         required: false
+      skip-test:
+        type: boolean
+        description: "Skip tests"
+        required: false
+        default: false
 
 permissions:
   id-token: write
@@ -50,6 +55,8 @@ jobs:
       - run: npm run build
 
       - run: npm run test
+        if: ${{ inputs.skip-test == false }}
+
       - name: Release package to private CodeArtifact
         uses: cloudscape-design/.github/.github/actions/release-package@main
         with:


### PR DESCRIPTION
*Description of changes:*

This adds an optional input `skip-test` for the `release` workflow that skips running `npm test`.
This will make it a little less painful to release changes to your dev branches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
