### PR TITLE
chore: Unlock package-lock deps during build phase

### DIFF
--- a/.github/actions/unlock-dependencies/action.yml
+++ b/.github/actions/unlock-dependencies/action.yml
@@ -1,0 +1,12 @@
+name: "Unlock Cloudscape dependencies in package-lock"
+description: "Removes all @cloudscape-design dependencies from package-lock file"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js 16
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - run: node ${{ github.action_path }}/index.js
+      shell: bash

--- a/.github/actions/unlock-dependencies/index.js
+++ b/.github/actions/unlock-dependencies/index.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Remove specific @cloudscape-design/* packages where we should always use the latest minor release.
+ */
+const filename = path.resolve(process.env.GITHUB_WORKSPACE, "package-lock.json");
+const packageLock = JSON.parse(fs.readFileSync(filename));
+
+function removeDependencies(dependencyName, packages) {
+  if (dependencyName.includes("@cloudscape-design/")) {
+    delete packages[dependencyName];
+  }
+}
+
+Object.keys(packageLock.packages).forEach((dependencyName) => {
+  removeDependencies(dependencyName, packageLock.packages);
+});
+
+Object.keys(packageLock.dependencies).forEach((dependencyName) => {
+  removeDependencies(dependencyName, packageLock.dependencies);
+});
+
+fs.writeFileSync(filename, JSON.stringify(packageLock, null, 2) + "\n");
+console.log("Removed @cloudscape-design/ dependencies from package-lock file");

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Unlock dependencies
+        uses: cloudscape-design/.github/.github/actions/unlock-dependencies@main
       - run: npm i --force
       - run: npm run lint
       - run: npm run build


### PR DESCRIPTION
*Issue #, if available:* AWSUI-20265

*Description of changes:*
This introduces a small workflow that removes all cloudscape-design dependencies from the package-lock of the calling package before running npm install. This is done so that the build is always run against the latest version available in npm. 
Previously this was handled by a preinstall script but this behavior was changed in npm8 to only run after install 

This workflow is only needed on build-lint-test as both dry-run and release modify the packages in package.json to point to either a file:// or to a next tag found in CodeArtifact. This already invalidates whatever is in the package-lock and so no need to apply the same logic here.

*How was this tested:*
Tested on a components branch that changed the workflow to point to this branch: https://github.com/cloudscape-design/components/actions/runs/4073758709/jobs/7018150631

The build fails because I regenerated the package-lock which brought in some other changes but the Remove cloudscape dependencies workflow from this change worked as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
