### PR TITLE
chore: Optionally upload artifacts from build to GitHub Artifacts

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -1,0 +1,24 @@
+name: "Upload artifact to GitHub Artifacts"
+description: "Compress and uploaded a given folder as an artifact to GitHub Artifacts"
+inputs:
+  path:
+    type: string
+    description: "A file, directory or wildcard pattern that describes what to upload"
+    required: true
+  name:
+    type: string
+    description: "Artifact name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create artifact
+      run: |
+        tar -zcvf ${{ inputs.name }}.tar.gz ${{ inputs.path }}
+      shell: bash
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.name }}.tar.gz

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,6 +8,13 @@ on:
         description: "Skip CodeQL checks"
         required: false
         default: false
+      artifact-path:
+        type: string
+        description: "An optional file, directory or wildcard pattern that describes what to upload"
+      artifact-name:
+        type: string
+        description: "An optional artifact name"
+        default: "artifact"
 
 permissions:
   actions: read
@@ -30,6 +37,12 @@ jobs:
         if: ${{ github.repository != 'cloudscape-design/components' }}
       - run: npm run test:unit
         if: ${{ github.repository == 'cloudscape-design/components' }}
+      - name: Upload Artifacts
+        if: ${{ inputs.artifact-path != '' }}
+        uses: cloudscape-design/.github/.github/actions/upload-artifact@main
+        with:
+          path: ${{ inputs.artifact-path }}
+          name: ${{ inputs.artifact-name }}
       - name: Codecov
         uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Introduce a custom action that compresses a given path and uploads it GitHub Artifacts. Optionally allow the build-lint-test workflow to upload a given path to GitHub Artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
