### PR TITLE
chore: Add deployment of static assets action

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,0 +1,24 @@
+name: "Download artifact"
+description: "Downloads and extracts an artifact from GitHub artifacts"
+inputs:
+  path:
+    type: string
+    description: "A directory path for the extracted artifact"
+    required: true
+  name:
+    type: string
+    description: "Artifact name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+    - name: Deploy
+      run: |
+        cd ${{ inputs.path }}
+        tar -xf *.tar.gz
+      shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        type: string
+        description: "Name of artifact to deploy"
+        required: true
+      deployment-path:
+        type: string
+        description: "Directory of assets to upload"
+        default: "."
+
+permissions:
+  id-token: write
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: https://d21d5uik3ws71m.cloudfront.net/${{ github.event.repository.name }}/${{ github.event.pull_request.head.sha }}/index.html
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_PREVIEW_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Download artifact
+        uses: cloudscape-design/.github/.github/actions/download-artifact@main
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: build
+      - name: Deploy
+        id: deploy
+        run: |
+          aws s3 cp ${{ inputs.deployment-path }} s3://${{ secrets.AWS_PREVIEW_BUCKET_NAME }}/${{ github.event.repository.name }}/${{ github.event.pull_request.head.sha }} --recursive
+        working-directory: build


### PR DESCRIPTION
*Description of changes:*
Adds a reusable workflow to deploy a github artifact that was create by the build-lint-test workflow

Uses third party github action chrnorm/deployment-action@v2 to manage deployment. Package is listed as MIT license and version is locked to tag v2.0.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
