### PR TITLE
chore: Stop using next tags overrides for builds

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -44,7 +44,6 @@ runs:
     - uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@main
       with:
         path: ${{ github.workspace }}/${{ inputs.package }}
-        type: local
 
     - name: npm install
       shell: bash

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -16,8 +16,4 @@ runs:
       with:
         node-version: 16
     - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/local.mjs
-      if: ${{ inputs.type == 'local' }}
-      shell: bash
-    - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/next.mjs
-      if: ${{ inputs.type == 'next' }}
       shell: bash

--- a/.github/actions/patch-local-dependencies/next.mjs
+++ b/.github/actions/patch-local-dependencies/next.mjs
@@ -1,3 +1,0 @@
-import { updatePackageJsons } from './utils.mjs';
-
-updatePackageJsons(() => 'next');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+
+      - run: npm install --force
+
+      - run: npm run build
+
+      - run: npm run test
+        if: ${{ inputs.skip-test == false }}
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -40,22 +48,6 @@ jobs:
         run: |
           echo Logging into repository $CODE_ARTIFACT_REPO
           aws codeartifact login --tool npm --repository $CODE_ARTIFACT_REPO --domain awsui --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region us-west-2 --namespace @cloudscape-design
-
-      - name: Make sure to use pre-release versions of our dependencies
-        uses: cloudscape-design/.github/.github/actions/patch-local-dependencies@main
-        with:
-          path: ${{ github.workspace }}
-          type: next
-
-      - run: npm install --force
-
-      - name: Restore locally modified files
-        run: git restore .
-
-      - run: npm run build
-
-      - run: npm run test
-        if: ${{ inputs.skip-test == false }}
 
       - name: Release package to private CodeArtifact
         uses: cloudscape-design/.github/.github/actions/release-package@main


### PR DESCRIPTION
Before this change, our builds tried to use `@next` releases of our packages from the staging repo.

This causes "works on my machine" kind of issues, because other builds (including local) use original packages from normal npm.

To minimize surprises, let's use normal versions all across our builds

Tested in this PR: https://github.com/cloudscape-design/components/pull/717

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
