### PR TITLE
chore: Do not fail deploy workflow if deploy action fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
   deploy:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment:
       name: preview
       url: https://d21d5uik3ws71m.cloudfront.net/${{ github.event.repository.name }}/${{ github.event.pull_request.head.sha }}/index.html


### PR DESCRIPTION
*Description of changes:*
Current pull requests from external repositories are unable to run this work flow due to the missing role required. This allows the build-lint-test workflow to still pass if the deploy fails for any reason.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
