### PR TITLE
allow release script to fail the workflow

### DIFF
--- a/.github/actions/release-package/index.mjs
+++ b/.github/actions/release-package/index.mjs
@@ -31,18 +31,14 @@ function releasePackage(packagePath) {
   if(packageJson.files) {
     packageJson.files.push(internalFolderName)
   }
-  
+
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
   // Publish to CodeArtifact
   console.info(`Publishing package ${packageJson.name} version ${packageJson.version} to dist-tag ${publishTag}`);
 
-  try {
-    execSync(`npm publish --tag ${publishTag}`, { stdio: 'inherit', cwd: packagePath });
-  } catch (e) {
-    console.error(`Publishing failed with ${e.status}: ${e.message}. ${e.stderr ? 'Full error: ' + e.stderr.toString() : ''}`);
-  }
-}  
+  execSync(`npm publish --tag ${publishTag}`, { stdio: 'inherit', cwd: packagePath });
+}
 
 function addManifest(data, packagePath) {
   mkdirSync(path.join(packagePath, internalFolderName), { recursive: true })


### PR DESCRIPTION
if anything went wrong, we would like to be notified about it, not just quietly move on. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
