### PR TITLE
Fail checks if codecov fails

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -47,6 +47,8 @@ jobs:
           name: ${{ inputs.artifact-name }}
       - name: Codecov
         uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
 
   codeql:
     if: ${{ inputs.skip-codeql == false }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sometimes the codecov upload silently fails, which leaves our Actions hanging. This change makes codecov upload errors fail the Action so it can be restarted more easily.

See https://github.com/codecov/codecov-action#usage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
