### PR TITLE
chore: Use optional codecov upload token

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -54,6 +54,7 @@ jobs:
         if: ${{ inputs.skip-codecov == false }}
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   codeql:


### PR DESCRIPTION
*Issue #, if available:* AWSUI-20481

*Description of changes:* Allow the usage of a Codecov upload token if it's available as a secret.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
