### PR TITLE
add board components to the dry-run workflow

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -61,7 +61,7 @@ runs:
       run: npm test
       working-directory: ${{ inputs.package }}
     - name: Pack artifacts
-      if: ${{ inputs.package != 'components' && inputs.package != 'test-utils' && inputs.package != 'theming-core' && inputs.package != 'demos' }}
+      if: ${{ inputs.package != 'components' && inputs.package != 'test-utils' && inputs.package != 'theming-core' && inputs.package != 'board-components' && inputs.package != 'demos' }}
       shell: bash
       working-directory: ${{ inputs.package }}
       run: |
@@ -99,6 +99,15 @@ runs:
         cd $GITHUB_WORKSPACE
         mv *-theming-build-*.tgz theming-build.tgz
         mv *-theming-runtime-*.tgz theming-runtime.tgz
+
+    - name: Package board components files
+      if: ${{ inputs.package == 'board-components' }}
+      shell: bash
+      working-directory: ${{ inputs.package }}
+      run: |
+        cd lib/components
+        npm pack
+        cp *-${{ inputs.package }}-*.tgz $GITHUB_WORKSPACE/${{ inputs.package }}.tgz
 
     - name: Package component files
       if: ${{ inputs.package == 'components' }}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -103,6 +103,26 @@ jobs:
           skip_tests: true
           download_dependencies: true
 
+  buildBoardComponents:
+    name: Build board components
+    runs-on: ubuntu-latest
+    needs:
+      - buildGlobalStyles
+      - buildBrowserTestTools
+      - buildDocumenter
+      - buildTestUtils
+      - buildComponentToolkit
+      - buildComponents
+    steps:
+      - name: Download component artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: components-package
+      - uses: cloudscape-design/.github/.github/actions/build-package@main
+        with:
+          package: board-components
+          download_dependencies: true
+
   unitTest:
     name: Components unit tests
     runs-on: ubuntu-latest
@@ -165,6 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - buildComponents
+      - buildBoardComponents
       - buildBrowserTestTools
       - buildCollectionHooks
       - buildTestUtils


### PR DESCRIPTION
*Issue #, if available:* AWSUI-20634

*Description of changes:*

Added https://github.com/cloudscape-design/board-components to the build pipeline

* The PR build does not represent the real state of the build, because it still uses `main` branch for the builds
* Demo run which is actually working: https://github.com/cloudscape-design/components/pull/896

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
