### PR TITLE
chore: Upgrade download/upload artifact actions

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Download artifacts
       if: ${{ inputs.download_dependencies == 'true' }}
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: dependencies
 
@@ -118,7 +118,7 @@ runs:
         tar -czf ../design-tokens.tgz --directory=lib/design-tokens .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.target_artifact }}
         path: ${{ inputs.artifact_path || format('{0}*.tgz', inputs.package) }}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -115,7 +115,7 @@ jobs:
       - buildComponents
     steps:
       - name: Download component artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: components-package
       - uses: cloudscape-design/.github/.github/actions/build-package@main
@@ -134,7 +134,7 @@ jobs:
         with:
           node-version: 16
       - name: Download component artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: components-package
       - name: Unpack components artifacts
@@ -153,7 +153,7 @@ jobs:
         with:
           node-version: 16
       - name: Download component artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: components-package
       - name: Unpack components artifacts
@@ -172,7 +172,7 @@ jobs:
         with:
           node-version: 16
       - name: Download component artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: components-package
       - name: Unpack components artifacts
@@ -193,7 +193,7 @@ jobs:
       - buildThemingCore
     steps:
       - name: Download component artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: components-package
       - name: Build


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Upgrade the last remaining NodeJS 12 actions in our workflows.

Tested for the components package here: https://github.com/cloudscape-design/components/pull/917

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
