### PR TITLE
chore: Pin CodeCov action to a specific hash

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -52,7 +52,7 @@ jobs:
           name: ${{ inputs.artifact-name }}
       - name: Codecov
         if: ${{ inputs.skip-codecov == false }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This change specifies a commit hash for the Codecov action. It's the [current latest commit](https://github.com/codecov/codecov-action/commits/main).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
