### PR TITLE
chore: Upgrade aws-actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       url: https://d21d5uik3ws71m.cloudfront.net/${{ github.event.repository.name }}/${{ github.event.pull_request.head.sha }}/index.html
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_PREVIEW_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ inputs.skip-test == false }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
           aws-region: us-west-2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrade aws-actions/configure-aws-credentials from v1 to v2

V2 uses Node16 by default: https://github.com/aws-actions/configure-aws-credentials/blob/v2.0.0/CHANGELOG.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
