### PR TITLE
Run codecov step regardless the build status

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -51,7 +51,7 @@ jobs:
           path: ${{ inputs.artifact-path }}
           name: ${{ inputs.artifact-name }}
       - name: Codecov
-        if: ${{ inputs.skip-codecov == false }}
+        if: ${{ inputs.skip-codecov == false && always() }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allowing test coverage to be reported even if the build fails

* Tested `skip-codecov: true` here: https://github.com/cloudscape-design/components/pull/1397
* Tested codecov reporting here: https://github.com/cloudscape-design/components/pull/1397
   * When build passes: https://github.com/cloudscape-design/components/actions/runs/5725809297/job/15515024542
   * When build fails: https://github.com/cloudscape-design/components/actions/runs/5726436948/job/15516886715

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
