### PR TITLE
chore: Lint only after building

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -5,21 +5,21 @@ on:
     inputs:
       skip-codeql:
         type: boolean
-        description: "Skip CodeQL checks"
+        description: 'Skip CodeQL checks'
         required: false
         default: false
       skip-codecov:
         type: boolean
-        description: "Skip code coverage step"
+        description: 'Skip code coverage step'
         required: false
         default: false
       artifact-path:
         type: string
-        description: "An optional file, directory or wildcard pattern that describes what to upload"
+        description: 'An optional file, directory or wildcard pattern that describes what to upload'
       artifact-name:
         type: string
-        description: "An optional artifact name"
-        default: "artifact"
+        description: 'An optional artifact name'
+        default: 'artifact'
 
 permissions:
   actions: read
@@ -38,8 +38,8 @@ jobs:
       - name: Unlock dependencies
         uses: cloudscape-design/.github/.github/actions/unlock-dependencies@main
       - run: npm i --force
-      - run: npm run lint
       - run: npm run build
+      - run: npm run lint
       - run: npm run test
         if: ${{ github.repository != 'cloudscape-design/components' }}
       - run: npm run test:unit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR moves the linting step until after the build has run. When a linting rule depends on type information, it needs to have access to all source code files, including those that are generated during the build, such as `src/internal/generated/custom-css-properties` in the components package. To get these files, the project has to be built first.

You can see an example failure in this build of [a PR that adds linting rules which depend on type information](https://github.com/cloudscape-design/components/pull/1450): https://github.com/cloudscape-design/components/actions/runs/5877911019/job/15938954873?pr=1450
```
/home/runner/work/components/components/src/flashbar/collapsible-flashbar.tsx
Error:   223:16  error    Unsafe member access .flashbarStackDepth on an `any` value                      @typescript-eslint/no-unsafe-member-access
```

The `any` value mentioned there comes from this import (which points to a file that does not yet exist at that stage):
```
import customCssProps from '../internal/generated/custom-css-properties';
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
