### PR TITLE
feat: Add jest shards in a11y tests

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -164,6 +164,9 @@ jobs:
   a11yTest:
     name: Components accessibility tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     needs:
       - buildComponents
     steps:
@@ -178,7 +181,7 @@ jobs:
       - name: Unpack components artifacts
         run: tar -xzf components-full.tgz
       - name: Accessibility tests
-        run: npm run test:a11y
+        run: npm run test:a11y -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
   demosTest:
     name: Demos tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the a11y tests takes around 30~35 minutes to be executed and it increases the waiting time for a PR to have a successful workflow action by almost 15 minutes as the highest tests that takes time after the a11y are the integ tests ( 15 mins )

This PR introduces jest shards, by which we divide the a11y into shards and each shard executes a subset of the tests in a separate machine. To create the shards mechanism we'll also have to merge the changes in the dry-run github workflow definition in this [PR](https://github.com/cloudscape-design/components/pull/1503).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
