### PR TITLE
upgrade nodejs to version 18

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -27,10 +27,10 @@ runs:
       with:
         repository: cloudscape-design/${{ inputs.package }}
         path: ${{ inputs.package }}
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Download artifacts
       if: ${{ inputs.download_dependencies == 'true' }}

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -11,9 +11,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/local.mjs
       shell: bash

--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -9,10 +9,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Define new version suffix
       id: vars

--- a/.github/actions/unlock-dependencies/action.yml
+++ b/.github/actions/unlock-dependencies/action.yml
@@ -4,9 +4,9 @@ description: "Removes all @cloudscape-design dependencies from package-lock file
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: node ${{ github.action_path }}/index.js
       shell: bash

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -5,21 +5,21 @@ on:
     inputs:
       skip-codeql:
         type: boolean
-        description: 'Skip CodeQL checks'
+        description: "Skip CodeQL checks"
         required: false
         default: false
       skip-codecov:
         type: boolean
-        description: 'Skip code coverage step'
+        description: "Skip code coverage step"
         required: false
         default: false
       artifact-path:
         type: string
-        description: 'An optional file, directory or wildcard pattern that describes what to upload'
+        description: "An optional file, directory or wildcard pattern that describes what to upload"
       artifact-name:
         type: string
-        description: 'An optional artifact name'
-        default: 'artifact'
+        description: "An optional artifact name"
+        default: "artifact"
 
 permissions:
   actions: read
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Unlock dependencies
         uses: cloudscape-design/.github/.github/actions/unlock-dependencies@main
       - run: npm i --force

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -129,10 +129,10 @@ jobs:
     needs:
       - buildComponents
     steps:
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -148,10 +148,10 @@ jobs:
     needs:
       - buildComponents
     steps:
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -167,10 +167,10 @@ jobs:
     needs:
       - buildComponents
     steps:
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - run: npm install --force
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrading to the latest LTS version of nodejs 18 since nodejs 16 is getting an end of life.

Ran a test draft PRs for other repos consuming this repo but with this branch instead:
- [components](https://github.com/cloudscape-design/components/pull/1530)
- [test-utils](https://github.com/cloudscape-design/test-utils/pull/34)
- [browser-test-utils](https://github.com/cloudscape-design/browser-test-tools/pull/61)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


