### PR TITLE
chore: Add parent task for a11y test shards

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -164,6 +164,14 @@ jobs:
   a11yTest:
     name: Components accessibility tests
     runs-on: ubuntu-latest
+    needs:
+      - a11yTestShards
+    steps:
+      - run: echo "Completed all accessibility tests"
+
+  a11yTestShards:
+    name: Components accessibility tests shard
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Adding a "dummy" parent task that waits for all the a11y test shards to finish. That way we dont have to specifically mention every shard in the list of required checks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
