### PR TITLE
chore: Use NodeJS 18 for all actions and workflows

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -27,10 +27,10 @@ runs:
       with:
         repository: cloudscape-design/${{ inputs.package }}
         path: ${{ inputs.package }}
-    - name: Use Node.js 16
+    - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Download artifacts
       if: ${{ inputs.download_dependencies == 'true' }}

--- a/.github/actions/patch-local-dependencies/action.yml
+++ b/.github/actions/patch-local-dependencies/action.yml
@@ -11,9 +11,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 16
+    - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: INPUT_PATH=${{ inputs.path }} INPUT_TYPE=${{ inputs.type }} node ${{ github.action_path }}/local.mjs
       shell: bash

--- a/.github/actions/release-package/action.yml
+++ b/.github/actions/release-package/action.yml
@@ -9,10 +9,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 16
+    - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Define new version suffix
       id: vars

--- a/.github/actions/unlock-dependencies/action.yml
+++ b/.github/actions/unlock-dependencies/action.yml
@@ -4,9 +4,9 @@ description: "Removes all @cloudscape-design dependencies from package-lock file
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js 16
+    - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: node ${{ github.action_path }}/index.js
       shell: bash

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Unlock dependencies
         uses: cloudscape-design/.github/.github/actions/unlock-dependencies@main
       - run: npm i --force

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -129,10 +129,10 @@ jobs:
     needs:
       - buildComponents
     steps:
-      - name: Use Node.js 16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -148,10 +148,10 @@ jobs:
     needs:
       - buildComponents
     steps:
-      - name: Use Node.js 16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:
@@ -178,10 +178,10 @@ jobs:
     needs:
       - buildComponents
     steps:
-      - name: Use Node.js 16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Download component artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - run: npm install --force
 


### PR DESCRIPTION
*Issue #, if available:* AWSUI-22318

*Description of changes:* Update all workflows and actions to use NodeJS 18 instead of 16.

A green dry-run can be found here: https://github.com/cloudscape-design/browser-test-tools/pull/66


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
